### PR TITLE
Adjust validation for final-form v4

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "final-form": "^3.0.0",
+    "final-form": "^4.0.0",
     "vue": "^2.0.0",
     "vue-router": "^3.0.0",
     "vue-final-form": "latest"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "bili": "^3.0.0",
     "eslint-config-rem": "^3.0.0",
-    "final-form": "^3.0.0",
+    "final-form": "^4.0.0",
     "gh-pages": "^1.0.0",
     "poi": "^9.1.4",
     "rollup-plugin-babel": "^3.0.3",
@@ -49,7 +49,7 @@
     }
   },
   "peerDependencies": {
-    "final-form": "^3.0.0"
+    "final-form": "^4.0.0"
   },
   "babel": {
     "presets": [

--- a/src/Field.js
+++ b/src/Field.js
@@ -1,5 +1,5 @@
 import { fieldSubscriptionItems } from 'final-form'
-import { getChildren, composeValidators } from './utils'
+import { getChildren, composeFieldValidators } from './utils'
 
 export default {
   name: 'final-field',
@@ -31,7 +31,7 @@ export default {
       this.fieldState = fieldState
       this.$emit('change', fieldState)
     }, subscription, {
-      validate: Array.isArray(this.validate) ? composeValidators(this.validate) : this.validate
+      getValidator: Array.isArray(this.validate) ? composeFieldValidators(this.validate) : () => this.validate
     })
   },
 

--- a/src/Form.js
+++ b/src/Form.js
@@ -1,6 +1,6 @@
 import { createForm, formSubscriptionItems } from 'final-form'
 import assign from 'nano-assign'
-import { getChildren, composeValidators } from './utils'
+import { getChildren, composeFormValidators } from './utils'
 
 const defaultSubscription = formSubscriptionItems.reduce(
   (result, key) => {
@@ -34,7 +34,7 @@ export default {
       finalForm: createForm({
         onSubmit: this.submit,
         initialValues: this.initialValues,
-        validate: Array.isArray(this.validate) ? composeValidators(this.validate) : this.validate
+        validate: Array.isArray(this.validate) ? composeFormValidators(this.validate) : this.validate
       }),
       formState: null
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,5 +2,11 @@ export const getChildren = children => {
   return Array.isArray(children) ? children : [children]
 }
 
-export const composeValidators = validators => (...args) =>
+const composeValidators = (validators, ...args) =>
   validators.reduce((error, validator) => error || validator(...args), undefined)
+
+export const composeFormValidators = validators => (...args) =>
+  composeValidators(validators, ...args)
+
+export const composeFieldValidators = validators => () => (...args) =>
+  composeValidators(validators, ...args)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3462,9 +3462,9 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
-final-form@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/final-form/-/final-form-3.1.0.tgz#b27fb2261e41ed68b99760f024431ef180461341"
+final-form@^4.0.0:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.6.1.tgz#e3f3058524c2eb8b950be452087ffe124e39554d"
 
 finalhandler@1.1.1:
   version "1.1.1"


### PR DESCRIPTION
I am not sure about bumping the `final-form` to `v4.0.0`, because we could use the [exported `version` constant](https://github.com/final-form/final-form/blob/aad3701906141dcad3d1a21a6847275a1ce39680/src/FinalForm.js#L30) and release changes from this PR as a minor release. I chose a slightly simpler solution, what do you thing @egoist?