### PR TITLE
Add form reinit on changed initialValues

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -47,6 +47,12 @@ export default {
     }
   },
 
+  watch: {
+    initialValues(newValue) {
+      this.finalForm.initialize(newValue);
+    }
+  },
+
   created() {
     this.unsubscribe = this.finalForm.subscribe(state => {
       this.formState = state


### PR DESCRIPTION
I store my `initialValues` as computed property getting data from `vuex store`. 

As my data are updated I need to refresh form state, but I can't do it because of `initialize` method could be only accessed within templates (why? can you describe it purpose?).

So the only exit is to update `FinalForm` component itself. 