### PR TITLE
Fix complex field types: input[type="checkbox"] and select[multiple]

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,9 +252,11 @@ The current value of this field. You should probably bind it to `:value` of `inp
 
 ##### events
 
-Type: `{ input: Function, focus: Function, blur: Function }`
+Type: `{ change: Function, input: Function, focus: Function, blur: Function }`
 
-Bind these event handlers to your `input` `textarea` element.
+Bind these event handlers to your `input`, `textarea`, or `select` element.
+
+Note: change is used for special complex elements (input[type="checkbox"] and select[multiple]). We defer to Vue to handle the model evaluation in these cases, so v-model must be bound to the props.value from the scoped slot.
 
 See [FieldState.change](https://github.com/final-form/final-form#change-value-any--void), [FieldState.focus](https://github.com/final-form/final-form#focus---void), [FieldState.blur](https://github.com/final-form/final-form#blur---void).
 

--- a/src/Field.js
+++ b/src/Field.js
@@ -1,5 +1,5 @@
 import { fieldSubscriptionItems } from 'final-form'
-import { getChildren, composeFieldValidators } from './utils'
+import { composeFieldValidators } from './utils'
 
 export default {
   name: 'final-field',
@@ -39,10 +39,15 @@ export default {
     this.unsubscribe()
   },
 
-  computed: {
-    fieldEvents() {
+  methods: {
+    isChangeTarget(target) {
+      return (target.nodeName === 'INPUT' && target.type === 'checkbox') ||
+        (target.nodeName === 'SELECT' && target.multiple)
+    },
+    fieldEvents(slotScope) {
       return {
-        input: e => this.fieldState.change(e.target.value),
+        change: e => this.isChangeTarget(e.target) && this.fieldState.change(slotScope.value),
+        input: e => !this.isChangeTarget(e.target) && this.fieldState.change(e.target.value),
         blur: () => this.fieldState.blur(),
         focus: () => this.fieldState.focus()
       }
@@ -51,22 +56,21 @@ export default {
 
   render() {
     const {
-      blur,
       change,
-      focus,
       value,
       name,
       ...meta
     } = this.fieldState
 
-    const children = this.$scopedSlots.default({
-      events: this.fieldEvents,
+    const slotScope = {
       change,
       value,
       name,
       meta
-    })
+    }
 
-    return getChildren(children)[0]
+    return this.$scopedSlots.default(Object.assign(slotScope, {
+      events: this.fieldEvents(slotScope)
+    }))
   }
 }


### PR DESCRIPTION
`input[type="checkbox"]` can represent boolean, string, and string[] data. `select[multiple]` expects an array, but `event.target.value` only represents a single string value.

Vue has resolved this logic within `v-model` (https://vuejs.org/v2/guide/forms.html#Checkbox, https://vuejs.org/v2/guide/forms.html#Checkbox-1). This update adds a `change` event listener to handle these more complex use-cases, allowing access to the value bound via `v-model` and updating the final-form state accordingly.