### PR TITLE
Pass the validateFields config property to final form

### DIFF
--- a/example/examples/Simple.vue
+++ b/example/examples/Simple.vue
@@ -5,7 +5,7 @@
       @change="updateState"
       :initialValues="initialValues">
       <form slot-scope="props" @submit="props.handleSubmit">
-        <FinalField name="email" :validate="required">
+        <FinalField name="email" :validate="required" :validateFields="[]">
           <div slot-scope="props">
             <input
               v-on="props.events"
@@ -20,7 +20,7 @@
             </span>
           </div>
         </FinalField>
-        <FinalField name="password" :validate="[range(6, 20), noSpecialChars]">
+        <FinalField name="password" :validate="[range(6, 20), noSpecialChars]" :validateFields="['confirmPassword']">
           <div slot-scope="props">
             <input
               v-on="props.events"
@@ -35,7 +35,7 @@
             </span>
           </div>
         </FinalField>
-        <FinalField name="confirmPassword" :validate="matchedPassword">
+        <FinalField name="confirmPassword" :validate="matchedPassword" :validateFields="[]">
           <div slot-scope="props">
             <input
               v-on="props.events"

--- a/src/Field.js
+++ b/src/Field.js
@@ -12,6 +12,7 @@ export default {
       type: String
     },
     validate: [Function, Array],
+    validateFields: Array,
     subscription: Object
   },
 
@@ -31,7 +32,8 @@ export default {
       this.fieldState = fieldState
       this.$emit('change', fieldState)
     }, subscription, {
-      getValidator: Array.isArray(this.validate) ? composeFieldValidators(this.validate) : () => this.validate
+      getValidator: Array.isArray(this.validate) ? composeFieldValidators(this.validate) : () => this.validate,
+      validateFields: this.validateFields
     })
   },
 


### PR DESCRIPTION
This is a useful feature in Final Form which allows you to restrict field level validations from only being called when the field itself, or a list of dependent fields, are changed.